### PR TITLE
Update documents

### DIFF
--- a/src/data/updates.rs
+++ b/src/data/updates.rs
@@ -16,6 +16,7 @@ impl Data {
         method: IndexDocumentsMethod,
         format: UpdateFormat,
         mut stream: impl futures::Stream<Item=Result<B, E>> + Unpin,
+        primary_key: Option<String>,
     ) -> anyhow::Result<UpdateStatus>
     where
         B: Deref<Target = [u8]>,
@@ -47,7 +48,7 @@ impl Data {
                 mmap = unsafe { memmap::Mmap::map(&file)? };
                 &mmap
             };
-            index_controller.add_documents(index, method, format, &bytes)
+            index_controller.add_documents(index, method, format, &bytes, primary_key)
         }).await??;
         Ok(update.into())
     }

--- a/src/index_controller/local_index_controller/mod.rs
+++ b/src/index_controller/local_index_controller/mod.rs
@@ -40,9 +40,10 @@ impl IndexController for LocalIndexController {
         method: milli::update::IndexDocumentsMethod,
         format: milli::update::UpdateFormat,
         data: &[u8],
+        primary_key: Option<String>,
     ) -> anyhow::Result<UpdateStatus<UpdateMeta, UpdateResult, String>> {
         let (_, update_store) = self.indexes.get_or_create_index(&index, self.update_db_size, self.index_db_size)?;
-        let meta = UpdateMeta::DocumentsAddition { method, format };
+        let meta = UpdateMeta::DocumentsAddition { method, format, primary_key };
         let pending = update_store.register_update(meta, data)?;
         Ok(pending.into())
     }

--- a/src/index_controller/mod.rs
+++ b/src/index_controller/mod.rs
@@ -31,7 +31,11 @@ pub struct IndexMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum UpdateMeta {
-    DocumentsAddition { method: IndexDocumentsMethod, format: UpdateFormat },
+    DocumentsAddition {
+        method: IndexDocumentsMethod,
+        format: UpdateFormat,
+        primary_key: Option<String>,
+    },
     ClearDocuments,
     DeleteDocuments,
     Settings(Settings),
@@ -128,6 +132,7 @@ pub trait IndexController {
         method: IndexDocumentsMethod,
         format: UpdateFormat,
         data: &[u8],
+        primary_key: Option<String>,
     ) -> anyhow::Result<UpdateStatus>;
 
     /// Clear all documents in the given index.


### PR DESCRIPTION
- implement document update route
- Allow to set primary key on document addition. Errors are ignored if the primary key is already set.

API change: json error are not returned synchronously, since the documents are deserialized asynchronously.