### PR TITLE
fix settings delete

### DIFF
--- a/meilisearch-http/src/data/updates.rs
+++ b/meilisearch-http/src/data/updates.rs
@@ -55,10 +55,11 @@ impl Data {
     pub async fn update_settings(
         &self,
         index: impl AsRef<str> + Send + Sync + 'static,
-        settings: Settings
+        settings: Settings,
+        create: bool,
     ) -> anyhow::Result<UpdateStatus> {
         let index_controller = self.index_controller.clone();
-        let update = tokio::task::spawn_blocking(move || index_controller.update_settings(index, settings)).await??;
+        let update = tokio::task::spawn_blocking(move || index_controller.update_settings(index, settings, create)).await??;
         Ok(update.into())
     }
 

--- a/meilisearch-http/src/index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/mod.rs
@@ -142,8 +142,9 @@ pub trait IndexController {
     fn delete_documents(&self, index: impl AsRef<str>, document_ids: Vec<String>) -> anyhow::Result<UpdateStatus>;
 
     /// Updates an index settings. If the index does not exist, it will be created when the update
-    /// is applied to the index.
-    fn update_settings<S: AsRef<str>>(&self, index_uid: S, settings: Settings) -> anyhow::Result<UpdateStatus>;
+    /// is applied to the index. `create` specifies whether an index should be created if not
+    /// existing.
+    fn update_settings<S: AsRef<str>>(&self, index_uid: S, settings: Settings, create: bool) -> anyhow::Result<UpdateStatus>;
 
     /// Create an index with the given `index_uid`.
     fn create_index(&self, index_settings: IndexSettings) -> Result<IndexMetadata>;

--- a/meilisearch-http/src/routes/settings/mod.rs
+++ b/meilisearch-http/src/routes/settings/mod.rs
@@ -26,7 +26,7 @@ macro_rules! make_setting_route {
                     $attr: Some(None),
                     ..Default::default()
                 };
-                match data.update_settings(index_uid.into_inner(), settings).await {
+                match data.update_settings(index_uid.into_inner(), settings, false).await {
                     Ok(update_status) => {
                         let json = serde_json::to_string(&update_status).unwrap();
                         Ok(HttpResponse::Ok().body(json))
@@ -48,7 +48,7 @@ macro_rules! make_setting_route {
                     ..Default::default()
                 };
 
-                match data.update_settings(index_uid.into_inner(), settings).await {
+                match data.update_settings(index_uid.into_inner(), settings, true).await {
                     Ok(update_status) => {
                         let json = serde_json::to_string(&update_status).unwrap();
                         Ok(HttpResponse::Ok().body(json))
@@ -137,7 +137,7 @@ async fn update_all(
     index_uid: web::Path<String>,
     body: web::Json<Settings>,
 ) -> Result<HttpResponse, ResponseError> {
-    match data.update_settings(index_uid.into_inner(), body.into_inner()).await {
+    match data.update_settings(index_uid.into_inner(), body.into_inner(), true).await {
         Ok(update_result) => {
             let json = serde_json::to_string(&update_result).unwrap();
             Ok(HttpResponse::Ok().body(json))
@@ -170,7 +170,7 @@ async fn delete_all(
     index_uid: web::Path<String>,
 ) -> Result<HttpResponse, ResponseError> {
     let settings = Settings::cleared();
-    match data.update_settings(index_uid.into_inner(), settings).await {
+    match data.update_settings(index_uid.into_inner(), settings, false).await {
         Ok(update_result) => {
             let json = serde_json::to_string(&update_result).unwrap();
             Ok(HttpResponse::Ok().body(json))

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -51,8 +51,6 @@ async fn test_partial_update() {
 }
 
 #[actix_rt::test]
-#[ignore]
-// need fix #54
 async fn delete_settings_unexisting_index() {
     let server = Server::new().await;
     let index = server.index("test");
@@ -123,7 +121,6 @@ macro_rules! test_setting_routes {
                 }
 
                 #[actix_rt::test]
-                #[ignore]
                 async fn delete_unexisting_index() {
                     let server = Server::new().await;
                     let url = format!("/indexes/test/settings/{}",


### PR DESCRIPTION
fix #54 

Add a flag on settings update to specify whether an index should be created if not existing. This flag is set to false for delete settings.