### PR TITLE
Fix bad index uid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "tokio",
+ "urlencoding",
  "uuid",
  "vergen",
 ]
@@ -3297,6 +3298,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "utf8-width"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -71,6 +71,7 @@ serde_url_params = "0.2.0"
 tempdir = "0.3.7"
 assert-json-diff = { branch = "master", git = "https://github.com/qdequele/assert-json-diff" }
 tokio = { version = "0.2", features = ["macros", "time"] }
+urlencoding = "1.1.1"
 
 [features]
 default = ["sentry"]

--- a/meilisearch-http/src/data/mod.rs
+++ b/meilisearch-http/src/data/mod.rs
@@ -8,6 +8,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use sha2::Digest;
+use anyhow::bail;
 
 use crate::index_controller::{IndexController, LocalIndexController, IndexMetadata, Settings, IndexSettings};
 use crate::option::Opt;
@@ -126,6 +127,9 @@ impl Data {
     }
 
     pub fn create_index(&self, name: impl AsRef<str>, primary_key: Option<impl AsRef<str>>) -> anyhow::Result<IndexMetadata> {
+        if !is_index_uid_valid(name.as_ref()) {
+            bail!("invalid index uid: {:?}", name.as_ref())
+        }
         let settings = IndexSettings {
             name: Some(name.as_ref().to_string()),
             primary_key: primary_key.map(|s| s.as_ref().to_string()),
@@ -145,3 +149,8 @@ impl Data {
         &self.api_keys
     }
 }
+
+fn is_index_uid_valid(uid: &str) -> bool {
+    uid.chars().all(|x| x.is_ascii_alphanumeric() || x == '-' || x == '_')
+}
+

--- a/meilisearch-http/tests/common/server.rs
+++ b/meilisearch-http/tests/common/server.rs
@@ -1,7 +1,8 @@
-use tempdir::TempDir;
+use actix_web::http::StatusCode;
 use byte_unit::{Byte, ByteUnit};
 use serde_json::Value;
-use actix_web::http::StatusCode;
+use tempdir::TempDir;
+use urlencoding::encode;
 
 use meilisearch_http::data::Data;
 use meilisearch_http::option::{Opt, IndexerOpts};
@@ -60,7 +61,7 @@ impl Server {
     /// Returns a view to an index. There is no guarantee that the index exists.
     pub fn index<'a>(&'a self, uid: impl AsRef<str>) -> Index<'a> {
         Index {
-            uid: uid.as_ref().to_string(),
+            uid: encode(uid.as_ref()),
             service: &self.service,
         }
     }

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -46,6 +46,22 @@ async fn add_documents_no_index_creation() {
 }
 
 #[actix_rt::test]
+async fn document_add_create_index_bad_uid() {
+    let server = Server::new().await;
+    let index = server.index("883  fj!");
+    let (_response, code) = index.add_documents(json!([]), None).await;
+    assert_eq!(code, 400);
+}
+
+#[actix_rt::test]
+async fn document_update_create_index_bad_uid() {
+    let server = Server::new().await;
+    let index = server.index("883  fj!");
+    let (_response, code) = index.update_documents(json!([]), None).await;
+    assert_eq!(code, 400);
+}
+
+#[actix_rt::test]
 async fn document_addition_with_primary_key() {
     let server = Server::new().await;
     let index = server.index("test");

--- a/meilisearch-http/tests/index/create_index.rs
+++ b/meilisearch-http/tests/index/create_index.rs
@@ -47,12 +47,10 @@ async fn create_existing_index() {
     assert_eq!(code, 400);
 }
 
-// test fails (issue #46)
 #[actix_rt::test]
-#[ignore]
 async fn create_with_invalid_index_uid() {
     let server = Server::new().await;
-    let index = server.index("test test");
+    let index = server.index("test test#!");
     let (_, code) = index.create(None).await;
     assert_eq!(code, 400);
 }

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -90,6 +90,15 @@ async fn update_setting_unexisting_index() {
     assert_eq!(code, 200);
 }
 
+#[actix_rt::test]
+async fn update_setting_unexisting_index_invalid_uid() {
+    let server = Server::new().await;
+    let index = server.index("test##!  ");
+    let (_response, code) = index.update_settings(json!({})).await;
+    println!("response: {}", _response);
+    assert_eq!(code, 400);
+}
+
 macro_rules! test_setting_routes {
     ($($setting:ident), *) => {
         $(


### PR DESCRIPTION
close #46

Adds a check and tests on all route that can create an index for the correct format of the index uid