### PR TITLE
remove duplicated pending update

### DIFF
--- a/meilisearch-http/src/index_controller/local_index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/local_index_controller/mod.rs
@@ -103,11 +103,27 @@ impl IndexController for LocalIndexController {
     fn all_update_status(&self, index: impl AsRef<str>) -> anyhow::Result<Vec<UpdateStatus<UpdateMeta, UpdateResult, String>>> {
         match self.indexes.index(&index)? {
             Some((_, update_store)) => {
-                let updates = update_store.iter_metas(|processing, processed, pending, aborted, failed| {
+                let updates = update_store.iter_metas(|processing, processed, aborted, pending, failed| {
+                    let processing_id = processing
+                        .as_ref()
+                        .map(|p| p.id());
+
                     Ok(processing
                         .map(UpdateStatus::from)
                         .into_iter()
-                        .chain(pending.filter_map(|p| p.ok()).map(|(_, u)| UpdateStatus::from(u)))
+                        .chain(pending.
+                            filter_map(|p| p.ok())
+                            // if an update is processing, filter out this update from the pending
+                            // updates.
+                            .filter(|(_, u)| {
+                                println!("processing: {:?}", processing_id);
+                                processing_id
+                                .map(|id| {
+                                    println!("id: {}, pending: {}", id, u.id());
+                                    id != u.id()
+                                })
+                                .unwrap_or(true)})
+                            .map(|(_, u)| UpdateStatus::from(u)))
                         .chain(aborted.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))
                         .chain(processed.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))
                         .chain(failed.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))

--- a/meilisearch-http/src/index_controller/local_index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/local_index_controller/mod.rs
@@ -116,8 +116,7 @@ impl IndexController for LocalIndexController {
                             // If an update is processing, filter out this update from the pending
                             // updates.
                             .filter(|(_, u)| processing_id
-                                .map(|id| id != u.id())
-                                .unwrap_or(true))
+                                .map_or(true, |id| id != u.id()))
                             .map(|(_, u)| UpdateStatus::from(u)))
                         .chain(aborted.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))
                         .chain(processed.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))

--- a/meilisearch-http/src/index_controller/local_index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/local_index_controller/mod.rs
@@ -112,17 +112,12 @@ impl IndexController for LocalIndexController {
                         .map(UpdateStatus::from)
                         .into_iter()
                         .chain(pending.
-                            filter_map(|p| p.ok())
-                            // if an update is processing, filter out this update from the pending
+                            filter_map(Result::ok)
+                            // If an update is processing, filter out this update from the pending
                             // updates.
-                            .filter(|(_, u)| {
-                                println!("processing: {:?}", processing_id);
-                                processing_id
-                                .map(|id| {
-                                    println!("id: {}, pending: {}", id, u.id());
-                                    id != u.id()
-                                })
-                                .unwrap_or(true)})
+                            .filter(|(_, u)| processing_id
+                                .map(|id| id != u.id())
+                                .unwrap_or(true))
                             .map(|(_, u)| UpdateStatus::from(u)))
                         .chain(aborted.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))
                         .chain(processed.filter_map(Result::ok).map(|(_, u)| UpdateStatus::from(u)))

--- a/meilisearch-http/tests/updates/mod.rs
+++ b/meilisearch-http/tests/updates/mod.rs
@@ -50,9 +50,7 @@ async fn list_no_updates() {
     assert!(response.as_array().unwrap().is_empty());
 }
 
-// TODO: fix #32
 #[actix_rt::test]
-#[ignore]
 async fn list_updates() {
     let server = Server::new().await;
     let index = server.index("test");


### PR DESCRIPTION
fix #32

When listing the updates, if there is a processing update, it is filtered out of the pending updates.

This way the pending update remains in the pending udpat store until it is processed.
