### PR TITLE
enable criterion setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "milli"
 version = "0.1.0"
-source = "git+https://github.com/meilisearch/milli.git?rev=794fce7#794fce7bff3e3461a7f3954fd97f58f8232e5a8e"
+source = "git+https://github.com/meilisearch/milli.git?rev=f190d5f#f190d5f496cc39517b6a81300c6dee9b6dba7a38"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1756,6 +1756,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
+ "slice-group-by",
  "smallstr",
  "smallvec",
  "tempfile",

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -38,7 +38,7 @@ main_error = "0.1.0"
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", branch = "main" }
 memmap = "0.7.0"
-milli = { git = "https://github.com/meilisearch/milli.git", rev = "794fce7" }
+milli = { git = "https://github.com/meilisearch/milli.git", rev = "f190d5f" }
 mime = "0.3.16"
 once_cell = "1.5.2"
 rand = "0.7.3"

--- a/meilisearch-http/src/data/mod.rs
+++ b/meilisearch-http/src/data/mod.rs
@@ -109,7 +109,7 @@ impl Data {
         let criteria = index
             .criteria(&txn)?
             .into_iter()
-            .map(|v| format!("{:?}", v))
+            .map(|v| format!("{}", v))
             .collect();
 
         Ok(Settings {

--- a/meilisearch-http/src/data/mod.rs
+++ b/meilisearch-http/src/data/mod.rs
@@ -109,7 +109,7 @@ impl Data {
         let criteria = index
             .criteria(&txn)?
             .into_iter()
-            .map(|v| format!("{}", v))
+            .map(|v| v.to_string())
             .collect();
 
         Ok(Settings {

--- a/meilisearch-http/src/data/mod.rs
+++ b/meilisearch-http/src/data/mod.rs
@@ -106,11 +106,17 @@ impl Data {
             .map(|(k, v)| (k, v.to_string()))
             .collect();
 
+        let criteria = index
+            .criteria(&txn)?
+            .into_iter()
+            .map(|v| format!("{:?}", v))
+            .collect();
+
         Ok(Settings {
             displayed_attributes: Some(Some(displayed_attributes)),
             searchable_attributes: Some(Some(searchable_attributes)),
             faceted_attributes: Some(Some(faceted_attributes)),
-            criteria: None,
+            ranking_rules: Some(Some(criteria)),
         })
     }
 

--- a/meilisearch-http/src/data/search.rs
+++ b/meilisearch-http/src/data/search.rs
@@ -62,7 +62,6 @@ impl SearchQuery {
             documents_ids,
             matching_words,
             candidates,
-            ..
         } = search.execute()?;
 
         let mut documents = Vec::new();

--- a/meilisearch-http/src/data/search.rs
+++ b/meilisearch-http/src/data/search.rs
@@ -62,6 +62,7 @@ impl SearchQuery {
             documents_ids,
             found_words,
             candidates,
+            ..
         } = search.execute()?;
 
         let mut documents = Vec::new();

--- a/meilisearch-http/src/index_controller/local_index_controller/update_handler.rs
+++ b/meilisearch-http/src/index_controller/local_index_controller/update_handler.rs
@@ -153,7 +153,7 @@ impl UpdateHandler {
         }
 
         // We transpose the settings JSON struct into a real setting update.
-        if let Some(ref criteria) = settings.criteria {
+        if let Some(ref criteria) = settings.ranking_rules {
             match criteria {
                 Some(criteria) => builder.set_criteria(criteria.clone()),
                 None => builder.reset_criteria(),

--- a/meilisearch-http/src/index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/mod.rs
@@ -83,7 +83,7 @@ pub struct Settings {
         deserialize_with = "deserialize_some",
         skip_serializing_if = "Option::is_none",
     )]
-    pub criteria: Option<Option<Vec<String>>>,
+    pub ranking_rules: Option<Option<Vec<String>>>,
 }
 
 impl Settings {
@@ -92,7 +92,7 @@ impl Settings {
             displayed_attributes: Some(None),
             searchable_attributes: Some(None),
             faceted_attributes: Some(None),
-            criteria: Some(None),
+            ranking_rules: Some(None),
         }
     }
 }

--- a/meilisearch-http/src/routes/settings/mod.rs
+++ b/meilisearch-http/src/routes/settings/mod.rs
@@ -103,11 +103,11 @@ make_setting_route!(
     //distinct_attribute
 //);
 
-//make_setting_route!(
-    //"/indexes/{index_uid}/settings/ranking-rules",
-    //Vec<String>,
-    //ranking_rules
-//);
+make_setting_route!(
+    "/indexes/{index_uid}/settings/ranking-rules",
+    Vec<String>,
+    ranking_rules
+);
 
 macro_rules! create_services {
     ($($mod:ident),*) => {
@@ -128,7 +128,8 @@ macro_rules! create_services {
 create_services!(
     faceted_attributes,
     displayed_attributes,
-    searchable_attributes
+    searchable_attributes,
+    ranking_rules
 );
 
 #[post("/indexes/{index_uid}/settings", wrap = "Authentication::Private")]

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -10,7 +10,6 @@ async fn get_settings_unexisting_index() {
 
 // test broken, should be fixed with milli#101
 #[actix_rt::test]
-#[ignore]
 async fn get_settings() {
     let server = Server::new().await;
     let index = server.index("test");
@@ -22,7 +21,7 @@ async fn get_settings() {
     assert_eq!(settings["displayedAttributes"], json!(["*"]));
     assert_eq!(settings["searchableAttributes"], json!(["*"]));
     assert_eq!(settings["facetedAttributes"], json!({}));
-    assert_eq!(settings["rankingRules"], json!(["typo", "words", "proximmity", "attributes", "wordsPosition", "exactness"]));
+    assert_eq!(settings["rankingRules"], json!(["typo", "words", "proximity", "attribute", "wordsPosition", "exactness"]));
 }
 
 #[actix_rt::test]

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -8,7 +8,9 @@ async fn get_settings_unexisting_index() {
     assert_eq!(code, 400)
 }
 
+// test broken, should be fixed with milli#101
 #[actix_rt::test]
+#[ignore]
 async fn get_settings() {
     let server = Server::new().await;
     let index = server.index("test");
@@ -16,10 +18,11 @@ async fn get_settings() {
     let (response, code) = index.settings().await;
     assert_eq!(code, 200);
     let settings = response.as_object().unwrap();
-    assert_eq!(settings.keys().len(), 3);
+    assert_eq!(settings.keys().len(), 4);
     assert_eq!(settings["displayedAttributes"], json!(["*"]));
     assert_eq!(settings["searchableAttributes"], json!(["*"]));
     assert_eq!(settings["facetedAttributes"], json!({}));
+    assert_eq!(settings["rankingRules"], json!(["typo", "words", "proximmity", "attributes", "wordsPosition", "exactness"]));
 }
 
 #[actix_rt::test]

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -8,7 +8,6 @@ async fn get_settings_unexisting_index() {
     assert_eq!(code, 400)
 }
 
-// test broken, should be fixed with milli#101
 #[actix_rt::test]
 async fn get_settings() {
     let server = Server::new().await;


### PR DESCRIPTION
enable the criterion setting.

Currently the criterion are returned with an uppercase, for lack of a `Display` impl in milli.

should be fixed with https://github.com/meilisearch/milli/pull/101, but require more work since transplant is not up to date with milli.

close #22