### PR TITLE
Make sure that we do not use jemalloc on macos

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -76,5 +76,5 @@ urlencoding = "1.1.1"
 [features]
 default = ["sentry"]
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = "0.3.2"


### PR DESCRIPTION
We were wrongly compiling jemalloc on macOS even though we did use it only on Linux.