### PR TITLE
restore name field in index meta

### DIFF
--- a/meilisearch-http/src/index_controller/mod.rs
+++ b/meilisearch-http/src/index_controller/mod.rs
@@ -27,6 +27,7 @@ pub type UpdateStatus = updates::UpdateStatus<UpdateMeta, UpdateResult, String>;
 #[serde(rename_all = "camelCase")]
 pub struct IndexMetadata {
     uid: String,
+    name: String,
     #[serde(flatten)]
     meta: index_actor::IndexMeta,
 }
@@ -176,7 +177,7 @@ impl IndexController {
         let uuid = self.uuid_resolver.create(uid.clone()).await?;
         let meta = self.index_handle.create_index(uuid, primary_key).await?;
         let _ = self.update_handle.create(uuid).await?;
-        let meta = IndexMetadata { uid, meta };
+        let meta = IndexMetadata { name: uid.clone(), uid, meta };
 
         Ok(meta)
     }
@@ -207,7 +208,7 @@ impl IndexController {
 
         for (uid, uuid) in uuids {
             let meta = self.index_handle.get_index_meta(uuid).await?;
-            let meta = IndexMetadata { uid, meta };
+            let meta = IndexMetadata { name: uid.clone(), uid, meta };
             ret.push(meta);
         }
 
@@ -260,7 +261,7 @@ impl IndexController {
 
         let uuid = self.uuid_resolver.resolve(uid.clone()).await?;
         let meta = self.index_handle.update_index(uuid, index_settings).await?;
-        let meta = IndexMetadata { uid, meta };
+        let meta = IndexMetadata { name: uid.clone(), uid, meta };
         Ok(meta)
     }
 
@@ -273,7 +274,7 @@ impl IndexController {
     pub async fn get_index(&self, uid: String) -> anyhow::Result<IndexMetadata> {
         let uuid = self.uuid_resolver.resolve(uid.clone()).await?;
         let meta = self.index_handle.get_index_meta(uuid).await?;
-        let meta = IndexMetadata { uid, meta };
+        let meta = IndexMetadata { name: uid.clone(), uid, meta };
         Ok(meta)
     }
 }

--- a/meilisearch-http/tests/index/create_index.rs
+++ b/meilisearch-http/tests/index/create_index.rs
@@ -9,11 +9,12 @@ async fn create_index_no_primary_key() {
 
     assert_eq!(code, 200);
     assert_eq!(response["uid"], "test");
+    assert_eq!(response["name"], "test");
     assert!(response.get("createdAt").is_some());
     assert!(response.get("updatedAt").is_some());
     assert_eq!(response["createdAt"], response["updatedAt"]);
     assert_eq!(response["primaryKey"], Value::Null);
-    assert_eq!(response.as_object().unwrap().len(), 4);
+    assert_eq!(response.as_object().unwrap().len(), 5);
 }
 
 #[actix_rt::test]
@@ -24,11 +25,12 @@ async fn create_index_with_primary_key() {
 
     assert_eq!(code, 200);
     assert_eq!(response["uid"], "test");
+    assert_eq!(response["name"], "test");
     assert!(response.get("createdAt").is_some());
     assert!(response.get("updatedAt").is_some());
     //assert_eq!(response["createdAt"], response["updatedAt"]);
     assert_eq!(response["primaryKey"], "primary");
-    assert_eq!(response.as_object().unwrap().len(), 4);
+    assert_eq!(response.as_object().unwrap().len(), 5);
 }
 
 // TODO: partial test since we are testing error, amd error is not yet fully implemented in

--- a/meilisearch-http/tests/index/get_index.rs
+++ b/meilisearch-http/tests/index/get_index.rs
@@ -13,11 +13,12 @@ async fn create_and_get_index() {
 
     assert_eq!(code, 200);
     assert_eq!(response["uid"], "test");
+    assert_eq!(response["name"], "test");
     assert!(response.get("createdAt").is_some());
     assert!(response.get("updatedAt").is_some());
     assert_eq!(response["createdAt"], response["updatedAt"]);
     assert_eq!(response["primaryKey"], Value::Null);
-    assert_eq!(response.as_object().unwrap().len(), 4);
+    assert_eq!(response.as_object().unwrap().len(), 5);
 }
 
 // TODO: partial test since we are testing error, amd error is not yet fully implemented in

--- a/meilisearch-http/tests/index/update_index.rs
+++ b/meilisearch-http/tests/index/update_index.rs
@@ -13,6 +13,7 @@ async fn update_primary_key() {
 
     assert_eq!(code, 200);
     assert_eq!(response["uid"], "test");
+    assert_eq!(response["name"], "test");
     assert!(response.get("createdAt").is_some());
     assert!(response.get("updatedAt").is_some());
 
@@ -21,7 +22,7 @@ async fn update_primary_key() {
     assert!(created_at < updated_at);
 
     assert_eq!(response["primaryKey"], "primary");
-    assert_eq!(response.as_object().unwrap().len(), 4);
+    assert_eq!(response.as_object().unwrap().len(), 5);
 }
 
 #[actix_rt::test]


### PR DESCRIPTION
Makes the IndexMetadata payload iso with legacy meilisearch and closes #67 
