### PR TITLE
Check json payload on document addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,6 +1823,7 @@ dependencies = [
  "milli",
  "mime",
  "once_cell",
+ "oxidized-json-checker",
  "parking_lot",
  "rand 0.7.3",
  "rayon",
@@ -2121,6 +2122,12 @@ checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "oxidized-json-checker"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938464aebf563f48ab86d1cfc0e2df952985c0b814d3108f41d1b85e7f5b0dac"
 
 [[package]]
 name = "page_size"

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -61,6 +61,7 @@ tempfile = "3.1.0"
 thiserror = "1.0.24"
 tokio = { version = "1", features = ["full"] }
 uuid = "0.8.2"
+oxidized-json-checker = "0.3.2"
 
 [dependencies.sentry]
 default-features = false


### PR DESCRIPTION
Check if the json payload in updates is valid. It uses a json validator to avoid allocation, and only serializes the json in case of error, to return a pretty message.