### PR TITLE
use write senders for updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-http"
-version = "0.21.0-alpha"
+version = "0.21.0-alpha.1"
 dependencies = [
  "actix-cors",
  "actix-http 3.0.0-beta.4",

--- a/meilisearch-http/src/index_controller/index_actor.rs
+++ b/meilisearch-http/src/index_controller/index_actor.rs
@@ -280,7 +280,7 @@ impl<S: IndexStore + Sync + Send> IndexActor<S> {
         meta: Processing<UpdateMeta>,
         data: File,
     ) -> Result<UpdateResult> {
-        debug!("Processing update {}", meta.id());
+        log::info!("Processing update {}", meta.id());
         let uuid = meta.index_uuid();
         let update_handler = self.update_handler.clone();
         let index = match self.store.get(*uuid).await? {
@@ -443,7 +443,7 @@ impl IndexActorHandle {
     ) -> anyhow::Result<UpdateResult> {
         let (ret, receiver) = oneshot::channel();
         let msg = IndexMsg::Update { ret, meta, data };
-        let _ = self.read_sender.send(msg).await;
+        let _ = self.write_sender.send(msg).await;
         Ok(receiver.await.expect("IndexActor has been killed")?)
     }
 
@@ -500,7 +500,7 @@ impl IndexActorHandle {
     pub async fn delete(&self, uuid: Uuid) -> Result<()> {
         let (ret, receiver) = oneshot::channel();
         let msg = IndexMsg::Delete { uuid, ret };
-        let _ = self.read_sender.send(msg).await;
+        let _ = self.write_sender.send(msg).await;
         Ok(receiver.await.expect("IndexActor has been killed")?)
     }
 

--- a/meilisearch-http/tests/settings/get_settings.rs
+++ b/meilisearch-http/tests/settings/get_settings.rs
@@ -19,7 +19,6 @@ async fn get_settings() {
     assert_eq!(settings.keys().len(), 4);
     assert_eq!(settings["displayedAttributes"], json!(["*"]));
     assert_eq!(settings["searchableAttributes"], json!(["*"]));
-    println!("{:?}", settings);
     assert_eq!(settings["attributesForFaceting"], json!({}));
     assert_eq!(
         settings["rankingRules"],


### PR DESCRIPTION
 Use write senders to send updates to the `IndexActor`, so updates are performed sequentially on all indexes.