### PR TITLE
Make updates atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "meilisearch-http"
-version = "0.21.0-alpha"
+version = "0.21.0-alpha.1"
 dependencies = [
  "actix-cors",
  "actix-http 3.0.0-beta.4",


### PR DESCRIPTION
Until now, the index_uid->uuid mapping was done before the update was written to disk in the case of automatic index creation. This was an issue when the update failed, and the index would still exists in the uuid resolver.

This is fixed by this pr, by first creating the update with an uuid if the index does not exist, and then register this uuid to the uuid resolver.

This is preliminary work to the implementation of snapshots (#19).

This pr also changes the `resolve` method on the `UuidResolver` to `get` to make it clearer.


The `create_uuid` method may be bound to disappear when the index name resolution is handled by a remote machine.