### PR TITLE
chore(ci): cache dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,23 @@ RUN     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 WORKDIR /meilisearch
 
-COPY    . .
+COPY    Cargo.lock .
+COPY    Cargo.toml .
+
+COPY    meilisearch-error/Cargo.toml meilisearch-error/
+COPY    meilisearch-http/Cargo.lock meilisearch-http/
+COPY    meilisearch-http/Cargo.toml meilisearch-http/
 
 ENV     RUSTFLAGS="-C target-feature=-crt-static"
 
+# Create dummy main.rs files for each workspace member to be able to compile all the dependencies
+RUN     find . -type d -name "meilisearch-*" | xargs -I{} sh -c 'mkdir {}/src; echo "fn main() { }" > {}/src/main.rs;'
+# Use `cargo build` instead of `cargo vendor` because we need to not only download but compile dependencies too
+RUN     $HOME/.cargo/bin/cargo build --release
+# Cleanup dummy main.rs files
+RUN     find . -path "*/src/main.rs" -delete
+
+COPY    . .
 RUN     $HOME/.cargo/bin/cargo build --release
 
 # Run


### PR DESCRIPTION
Resolves https://github.com/meilisearch/transplant/issues/126

---

1st build when no dependencies cache is present yet
```console
➜ transplant (docker-deps-cache) ✗ time docker build .
Sending build context to Docker daemon  863.2kB
Step 1/23 : FROM    alpine:3.10 AS compiler

...

Successfully built 4f520fd8a831
docker build .  0.40s user 0.42s system 0% cpu 24:07.02 total
```

Subsequent builds
```console
➜ transplant (docker-deps-cache) ✗ time docker build .
Sending build context to Docker daemon  863.2kB
Step 1/23 : FROM    alpine:3.10 AS compiler

...

Step 16/23 : RUN     $HOME/.cargo/bin/cargo build --release
 ---> Running in 459a71ed3906
   Compiling serde v1.0.124
   Compiling bitflags v1.2.1
   Compiling num-traits v0.2.14
   Compiling num-integer v0.1.44
   Compiling semver-parser v0.10.2
   Compiling time v0.1.44
   Compiling semver v0.11.0
   Compiling rustc_version v0.3.3
   Compiling meilisearch-error v0.19.0 (/meilisearch/meilisearch-error)
   Compiling chrono v0.4.19
   Compiling vergen v3.2.0
   Compiling meilisearch-http v0.21.0-alpha.1 (/meilisearch/meilisearch-http)
    Finished release [optimized + debuginfo] target(s) in 5m 54s
Removing intermediate container 459a71ed3906

...

Successfully built 8cd59bef90c5
docker build .  0.23s user 0.35s system 0% cpu 6:05.90 total
