### PR TITLE
fix(ci, http): commit_sha and commit_date in docker builds

### DIFF
--- a/.github/workflows/publish_to_docker.yml
+++ b/.github/workflows/publish_to_docker.yml
@@ -11,10 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Set COMMIT_DATE env variable
+        run: |
+          echo "COMMIT_DATE=$( git log --pretty=format:'%ad' -n1 --date=short )" >> $GITHUB_ENV
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
+        env:
+          COMMIT_SHA: ${{ github.sha }}
         with:
           name: getmeili/meilisearch
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_names: true
+          buildargs: COMMIT_SHA,COMMIT_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ RUN     $HOME/.cargo/bin/cargo build --release
 # Cleanup dummy main.rs files
 RUN     find . -path "*/src/main.rs" -delete
 
+ARG     COMMIT_SHA
+ARG     COMMIT_DATE
+ENV     COMMIT_SHA=${COMMIT_SHA}
+ENV     COMMIT_DATE=${COMMIT_DATE}
+
 COPY    . .
 RUN     $HOME/.cargo/bin/cargo build --release
 

--- a/meilisearch-http/src/routes/stats.rs
+++ b/meilisearch-http/src/routes/stats.rs
@@ -56,9 +56,18 @@ struct VersionResponse {
 
 #[get("/version", wrap = "Authentication::Private")]
 async fn get_version() -> HttpResponse {
-   HttpResponse::Ok().json(VersionResponse {
-        commit_sha: env!("VERGEN_SHA").to_string(),
-        build_date: env!("VERGEN_BUILD_TIMESTAMP").to_string(),
+    let commit_sha = match option_env!("COMMIT_SHA") {
+        Some("") | None => env!("VERGEN_SHA"),
+        Some(commit_sha) => commit_sha
+    };
+    let commit_date = match option_env!("COMMIT_DATE") {
+        Some("") | None => env!("VERGEN_COMMIT_DATE"),
+        Some(commit_date) => commit_date
+    };
+
+    HttpResponse::Ok().json(VersionResponse {
+        commit_sha: commit_sha.to_string(),
+        build_date: commit_date.to_string(),
         pkg_version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }


### PR DESCRIPTION
Resolves https://github.com/meilisearch/MeiliSearch/issues/712 and https://github.com/meilisearch/MeiliSearch/issues/837

---

Without build args
```console
➜ transplant (fix-docker-commit-sha) ✗ docker build -t meilisearch .                                               

...

Successfully built 6b2f6dfb9aa8
Successfully tagged meilisearch:latest

➜ transplant (fix-docker-commit-sha) ✗ docker run -it -d -p 7700:7700 meilisearch ./meilisearch --no-analytics=true
a9c87c21bce3c57f4e50dada90b6f449d973ec25427ae06772253a4ee0440b7b

➜ transplant (fix-docker-commit-sha) ✗ curl http://localhost:7700/version                                          
{"commitSha":"UNKNOWN","buildDate":"UNKNOWN","pkgVersion":"0.21.0-alpha.1"}
```

With correct build args
```console
➜ transplant (fix-docker-commit-sha) ✗ docker build --build-arg COMMIT_SHA=$(git rev-parse HEAD) --build-arg COMMIT_DATE=$(git log --pretty=format:'%ad' -n1 --date=short) -t meilisearch .

...

Successfully built 8b3b188315ee
Successfully tagged meilisearch:latest

➜ transplant (fix-docker-commit-sha) ✗ docker run -it -d -p 7700:7700 meilisearch ./meilisearch --no-analytics=true
f61b9c026d12a8eaef171caf4d817d1e41367ce9fda8a631b36b81c986cd3d00

➜ transplant (fix-docker-commit-sha) ✗ curl http://localhost:7700/version                                          
{"commitSha":"4fc7d238106c564ed2dd2f05b9f00f7150eb0c62","buildDate":"2021-03-30","pkgVersion":"0.21.0-alpha.1"}
```