### PR TITLE
fix(http, index): analyzer config stop words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,7 +1818,7 @@ dependencies = [
  "log",
  "main_error",
  "meilisearch-error",
- "meilisearch-tokenizer",
+ "meilisearch-tokenizer 0.1.1 (git+https://github.com/meilisearch/Tokenizer.git?branch=main)",
  "memmap",
  "milli",
  "mime",
@@ -1845,6 +1845,22 @@ dependencies = [
  "urlencoding",
  "uuid",
  "vergen",
+]
+
+[[package]]
+name = "meilisearch-tokenizer"
+version = "0.1.1"
+source = "git+https://github.com/meilisearch/Tokenizer.git?tag=v0.1.4#31ba3ff4a15501f12b7d37ac64ddce7c35a9757c"
+dependencies = [
+ "character_converter",
+ "cow-utils",
+ "deunicode",
+ "fst",
+ "jieba-rs",
+ "once_cell",
+ "slice-group-by",
+ "unicode-segmentation",
+ "whatlang",
 ]
 
 [[package]]
@@ -1891,7 +1907,7 @@ dependencies = [
 [[package]]
 name = "milli"
 version = "0.1.0"
-source = "git+https://github.com/meilisearch/milli.git?rev=b7b23cd#b7b23cd4a8e62932c66c2ebedf9d89ddf089e299"
+source = "git+https://github.com/meilisearch/milli.git?rev=56777af#56777af8e4870a944629a8e31c40f7fecd26a9d5"
 dependencies = [
  "anyhow",
  "bstr",
@@ -1911,7 +1927,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "logging_timer",
- "meilisearch-tokenizer",
+ "meilisearch-tokenizer 0.1.1 (git+https://github.com/meilisearch/Tokenizer.git?tag=v0.1.4)",
  "memmap",
  "num-traits",
  "obkv",

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -42,7 +42,7 @@ main_error = "0.1.0"
 meilisearch-error = { path = "../meilisearch-error" }
 meilisearch-tokenizer = { git = "https://github.com/meilisearch/Tokenizer.git", branch = "main" }
 memmap = "0.7.0"
-milli = { git = "https://github.com/meilisearch/milli.git", rev = "b7b23cd" }
+milli = { git = "https://github.com/meilisearch/milli.git", rev = "56777af" }
 mime = "0.3.16"
 once_cell = "1.5.2"
 parking_lot = "0.11.1"

--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -156,7 +156,10 @@ pub struct Highlighter<'a, A> {
 
 impl<'a, A: AsRef<[u8]>> Highlighter<'a, A> {
     pub fn new(stop_words: &'a fst::Set<A>) -> Self {
-        let analyzer = Analyzer::new(AnalyzerConfig::default_with_stopwords(stop_words));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(stop_words);
+
+        let analyzer = Analyzer::new(config);
 
         Self { analyzer }
     }


### PR DESCRIPTION
Implement new way of initializing `AnalyzerConfig`'s stopwords (https://github.com/meilisearch/Tokenizer/pull/31 and https://github.com/meilisearch/Tokenizer/pull/32)