### PR TITLE
Fix commit date & SHA in startup message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ RUN     find . -path "*/src/main.rs" -delete
 
 ARG     COMMIT_SHA
 ARG     COMMIT_DATE
-ENV     COMMIT_SHA=${COMMIT_SHA}
-ENV     COMMIT_DATE=${COMMIT_DATE}
+ENV     COMMIT_SHA=${COMMIT_SHA} COMMIT_DATE=${COMMIT_DATE}
 
 COPY    . .
 RUN     $HOME/.cargo/bin/cargo build --release

--- a/meilisearch-http/src/main.rs
+++ b/meilisearch-http/src/main.rs
@@ -100,6 +100,15 @@ async fn run_http(
 }
 
 pub fn print_launch_resume(opt: &Opt, data: &Data) {
+    let commit_sha = match option_env!("COMMIT_SHA") {
+        Some("") | None => env!("VERGEN_SHA"),
+        Some(commit_sha) => commit_sha
+    };
+    let commit_date = match option_env!("COMMIT_DATE") {
+        Some("") | None => env!("VERGEN_COMMIT_DATE"),
+        Some(commit_date) => commit_date
+    };
+
     let ascii_name = r#"
 888b     d888          d8b 888 d8b  .d8888b.                                    888
 8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
@@ -116,11 +125,8 @@ pub fn print_launch_resume(opt: &Opt, data: &Data) {
     eprintln!("Database path:\t\t{:?}", opt.db_path);
     eprintln!("Server listening on:\t\"http://{}\"", opt.http_addr);
     eprintln!("Environment:\t\t{:?}", opt.env);
-    eprintln!("Commit SHA:\t\t{:?}", env!("VERGEN_SHA").to_string());
-    eprintln!(
-        "Build date:\t\t{:?}",
-        env!("VERGEN_BUILD_TIMESTAMP").to_string()
-    );
+    eprintln!("Commit SHA:\t\t{:?}", commit_sha.to_string());
+    eprintln!("Commit date:\t\t{:?}", commit_date.to_string());
     eprintln!(
         "Package version:\t{:?}",
         env!("CARGO_PKG_VERSION").to_string()

--- a/meilisearch-http/src/routes/stats.rs
+++ b/meilisearch-http/src/routes/stats.rs
@@ -81,7 +81,7 @@ async fn get_stats(data: web::Data<Data>) -> Result<HttpResponse, ResponseError>
 #[serde(rename_all = "camelCase")]
 struct VersionResponse {
     commit_sha: String,
-    build_date: String,
+    commit_date: String,
     pkg_version: String,
 }
 
@@ -98,7 +98,7 @@ async fn get_version() -> HttpResponse {
 
     HttpResponse::Ok().json(VersionResponse {
         commit_sha: commit_sha.to_string(),
-        build_date: commit_date.to_string(),
+        commit_date: commit_date.to_string(),
         pkg_version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }

--- a/meilisearch-http/tests/stats/mod.rs
+++ b/meilisearch-http/tests/stats/mod.rs
@@ -9,7 +9,7 @@ async fn get_settings_unexisting_index() {
     assert_eq!(code, 200);
     let version = response.as_object().unwrap();
     assert!(version.get("commitSha").is_some());
-    assert!(version.get("buildDate").is_some());
+    assert!(version.get("commitDate").is_some());
     assert!(version.get("pkgVersion").is_some());
 }
 


### PR DESCRIPTION
Resolves https://github.com/meilisearch/transplant/issues/137
Resolves https://github.com/meilisearch/transplant/issues/138

---
I ran a GitHub Action towards my own dockerhub: https://github.com/shekhirin/transplant/actions/runs/732666353

Startup message now shows correct `Commit SHA` and `Commit date` (changed from `Build date`).
```console
➜ transplant (shekhirin/startup-git-vars) ✔ docker run -it -p 7700:7700 shekhirin/meilisearch:v0.21.0-alpha.2 ./meilisearch --no-analytics=true
Unable to find image 'shekhirin/meilisearch:v0.21.0-alpha.2' locally
v0.21.0-alpha.2: Pulling from shekhirin/meilisearch
bfdacc68c91b: Already exists 
73b1ed30fa0b: Pull complete 
6607217ed754: Pull complete 
Digest: sha256:31bd6ac37e8711ab9d4123cf2ba2f942686569f08d68cfed8643752f381bfb74
Status: Downloaded newer image for shekhirin/meilisearch:v0.21.0-alpha.2

888b     d888          d8b 888 d8b  .d8888b.                                    888
8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
88888b.d88888              888     Y88b.                                        888
888Y88888P888  .d88b.  888 888 888  "Y888b.    .d88b.   8888b.  888d888 .d8888b 88888b.
888 Y888P 888 d8P  Y8b 888 888 888     "Y88b. d8P  Y8b     "88b 888P"  d88P"    888 "88b
888  Y8P  888 88888888 888 888 888       "888 88888888 .d888888 888    888      888  888
888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888

Database path:          "./data.ms"
Server listening on:    "http://0.0.0.0:7700"
Environment:            "development"
Commit SHA:             "038f1c740198f974743ba87fce7b74a8d0b71b5c"
Commit date:            "2021-04-09"
Package version:        "0.21.0-alpha.2"
Sentry DSN:             "https://5ddfa22b95f241198be2271aaf028653@sentry.io/3060337"
Anonymous telemetry:    "Disabled"

No master key found; The server will accept unidentified requests. If you need some protection in development mode, please export a key: export MEILI_MASTER_KEY=xxx

Documentation:          https://docs.meilisearch.com
Source code:            https://github.com/meilisearch/meilisearch
Contact:                https://docs.meilisearch.com/resources/contact.html or bonjour@meilisearch.com

[2021-04-09T10:29:49Z INFO  actix_server::builder] Starting 2 workers
[2021-04-09T10:29:49Z INFO  actix_server::builder] Starting "actix-web-service-0.0.0.0:7700" service on 0.0.0.0:7700
[2021-04-09T10:29:49Z INFO  meilisearch_http::index_controller::uuid_resolver::actor] uuid resolver started
[2021-04-09T10:29:49Z INFO  meilisearch_http::index_controller::update_actor::actor] Started update actor.
```

Endpoint also works as expected (`buildDate` -> `commitDate`)
```console
➜ transplant (shekhirin/startup-git-vars) ✔ curl http://localhost:7700/version
{"commitSha":"038f1c740198f974743ba87fce7b74a8d0b71b5c","commitDate":"2021-04-09","pkgVersion":"0.21.0-alpha.2"}
```