### PR TITLE
Update mini-dashboard with version 0.1.2

### DIFF
--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -117,5 +117,5 @@ default = ["telemetry", "mini-dashboard"]
 jemallocator = "0.3.2"
 
 [package.metadata.mini-dashboard]
-assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.1/build.zip"
-sha1 = "f4247f8f534214e2811637e0555347c3f6bf5794"
+assets-url = "https://github.com/meilisearch/mini-dashboard/releases/download/v0.1.2/build.zip"
+sha1 = "881949457a710a22b5cefcb0418038ceb8b0eb26"


### PR DESCRIPTION
Update of the mini-dashboard sha1 & assets-url, due to a new release