### PR TITLE
Convert UpdateStatus to legacy meilisearch format

### DIFF
--- a/meilisearch-http/src/index_controller/updates.rs
+++ b/meilisearch-http/src/index_controller/updates.rs
@@ -84,6 +84,10 @@ impl Processed {
     pub fn id(&self) -> u64 {
         self.from.id()
     }
+
+    pub fn meta(&self) -> &UpdateMeta {
+        self.from.meta()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -132,20 +136,28 @@ impl Aborted {
     pub fn id(&self) -> u64 {
         self.from.id()
     }
+
+    pub fn meta(&self) -> &UpdateMeta {
+        self.from.meta()
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Failed {
     #[serde(flatten)]
-    from: Processing,
-    error: UpdateError,
-    failed_at: DateTime<Utc>,
+    pub from: Processing,
+    pub error: UpdateError,
+    pub failed_at: DateTime<Utc>,
 }
 
 impl Failed {
     pub fn id(&self) -> u64 {
         self.from.id()
+    }
+
+    pub fn meta(&self) -> &UpdateMeta {
+        self.from.meta()
     }
 }
 
@@ -167,6 +179,16 @@ impl UpdateStatus {
             UpdateStatus::Processed(u) => u.id(),
             UpdateStatus::Aborted(u) => u.id(),
             UpdateStatus::Failed(u) => u.id(),
+        }
+    }
+
+    pub fn meta(&self) -> &UpdateMeta {
+        match self {
+            UpdateStatus::Processing(u) => u.meta(),
+            UpdateStatus::Enqueued(u) => u.meta(),
+            UpdateStatus::Processed(u) => u.meta(),
+            UpdateStatus::Aborted(u) => u.meta(),
+            UpdateStatus::Failed(u) => u.meta(),
         }
     }
 

--- a/meilisearch-http/src/routes/index.rs
+++ b/meilisearch-http/src/routes/index.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::ResponseError;
 use crate::helpers::Authentication;
-use crate::routes::IndexParam;
+use super::{UpdateStatusResponse, IndexParam};
 use crate::Data;
 
 pub fn services(cfg: &mut web::ServiceConfig) {
@@ -129,7 +129,10 @@ async fn get_update_status(
         .get_update_status(params.index_uid, params.update_id)
         .await;
     match result {
-        Ok(meta) => Ok(HttpResponse::Ok().json(meta)),
+        Ok(meta) => {
+            let meta = UpdateStatusResponse::from(meta);
+            Ok(HttpResponse::Ok().json(meta))
+        },
         Err(e) => {
             Ok(HttpResponse::BadRequest().json(serde_json::json!({ "error": e.to_string() })))
         }
@@ -143,7 +146,14 @@ async fn get_all_updates_status(
 ) -> Result<HttpResponse, ResponseError> {
     let result = data.get_updates_status(path.into_inner().index_uid).await;
     match result {
-        Ok(metas) => Ok(HttpResponse::Ok().json(metas)),
+        Ok(metas) => {
+            let metas = metas
+                .into_iter()
+                .map(UpdateStatusResponse::from)
+                .collect::<Vec<_>>();
+
+            Ok(HttpResponse::Ok().json(metas))
+        },
         Err(e) => {
             Ok(HttpResponse::BadRequest().json(serde_json::json!({ "error": e.to_string() })))
         }

--- a/meilisearch-http/src/routes/mod.rs
+++ b/meilisearch-http/src/routes/mod.rs
@@ -1,5 +1,11 @@
+use std::time::Duration;
+
 use actix_web::{get, HttpResponse};
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+use crate::index::Settings;
+use crate::index_controller::{UpdateMeta, UpdateResult, UpdateStatus};
 
 pub mod document;
 pub mod dump;
@@ -10,6 +16,193 @@ pub mod search;
 pub mod settings;
 pub mod stats;
 pub mod synonym;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "name")]
+pub enum UpdateType {
+    ClearAll,
+    Customs,
+    DocumentsAddition {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number: Option<usize>
+    },
+    DocumentsPartial {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number: Option<usize>
+    },
+    DocumentsDeletion {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        number: Option<usize>
+    },
+    Settings { settings: Settings },
+}
+
+impl From<&UpdateStatus> for UpdateType {
+    fn from(other: &UpdateStatus) -> Self {
+        use milli::update::IndexDocumentsMethod::*;
+
+        match other.meta() {
+            UpdateMeta::DocumentsAddition { method, .. } => {
+                let number = match other {
+                    UpdateStatus::Processed(processed) => match processed.success {
+                        UpdateResult::DocumentsAddition(ref addition) => {
+                            Some(addition.nb_documents)
+                        }
+                        _ => None,
+                    },
+                    _ => None,
+                };
+
+                match method {
+                    ReplaceDocuments => UpdateType::DocumentsAddition { number },
+                    UpdateDocuments => UpdateType::DocumentsPartial { number },
+                    _ => unreachable!(),
+                }
+            }
+            UpdateMeta::ClearDocuments => UpdateType::ClearAll,
+            UpdateMeta::DeleteDocuments => {
+                let number = match other {
+                    UpdateStatus::Processed(processed) => match processed.success {
+                        UpdateResult::DocumentDeletion { deleted } => Some(deleted as usize),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                UpdateType::DocumentsDeletion { number }
+            }
+            UpdateMeta::Settings(settings) => UpdateType::Settings {
+                settings: settings.clone(),
+            },
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessedUpdateResult {
+    pub update_id: u64,
+    #[serde(rename = "type")]
+    pub update_type: UpdateType,
+    pub duration: f64, // in seconds
+    pub enqueued_at: DateTime<Utc>,
+    pub processed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FailedUpdateResult {
+    pub update_id: u64,
+    #[serde(rename = "type")]
+    pub update_type: UpdateType,
+    pub error: String,
+    pub error_type: String,
+    pub error_code: String,
+    pub error_link: String,
+    pub duration: f64, // in seconds
+    pub enqueued_at: DateTime<Utc>,
+    pub processed_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnqueuedUpdateResult {
+    pub update_id: u64,
+    #[serde(rename = "type")]
+    pub update_type: UpdateType,
+    pub enqueued_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_processing_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+pub enum UpdateStatusResponse {
+    Enqueued {
+        #[serde(flatten)]
+        content: EnqueuedUpdateResult,
+    },
+    Processing {
+        #[serde(flatten)]
+        content: EnqueuedUpdateResult,
+    },
+    Failed {
+        #[serde(flatten)]
+        content: FailedUpdateResult,
+    },
+    Processed {
+        #[serde(flatten)]
+        content: ProcessedUpdateResult,
+    },
+}
+
+impl From<UpdateStatus> for UpdateStatusResponse {
+    fn from(other: UpdateStatus) -> Self {
+        let update_type = UpdateType::from(&other);
+
+        match other {
+            UpdateStatus::Processing(processing) => {
+                let content = EnqueuedUpdateResult {
+                    update_id: processing.id(),
+                    update_type,
+                    enqueued_at: processing.from.enqueued_at,
+                    started_processing_at: Some(processing.started_processing_at),
+                };
+                UpdateStatusResponse::Processing { content }
+            }
+            UpdateStatus::Enqueued(enqueued) => {
+                let content = EnqueuedUpdateResult {
+                    update_id: enqueued.id(),
+                    update_type,
+                    enqueued_at: enqueued.enqueued_at,
+                    started_processing_at: None,
+                };
+                UpdateStatusResponse::Enqueued { content }
+            }
+            UpdateStatus::Processed(processed) => {
+                let duration = processed
+                    .processed_at
+                    .signed_duration_since(processed.from.started_processing_at)
+                    .num_milliseconds();
+
+                // necessary since chrono::duration don't expose a f64 secs method.
+                let duration = Duration::from_millis(duration as u64).as_secs_f64();
+
+                let content = ProcessedUpdateResult {
+                    update_id: processed.id(),
+                    update_type,
+                    duration,
+                    enqueued_at: processed.from.from.enqueued_at,
+                    processed_at: processed.processed_at,
+                };
+                UpdateStatusResponse::Processed { content }
+            }
+            UpdateStatus::Aborted(_) => unreachable!(),
+            UpdateStatus::Failed(failed) => {
+                let duration = failed
+                    .failed_at
+                    .signed_duration_since(failed.from.started_processing_at)
+                    .num_milliseconds();
+
+                // necessary since chrono::duration don't expose a f64 secs method.
+                let duration = Duration::from_millis(duration as u64).as_secs_f64();
+
+                let content = FailedUpdateResult {
+                    update_id: failed.id(),
+                    update_type,
+                    error: failed.error,
+                    error_type: String::from("todo"),
+                    error_code: String::from("todo"),
+                    error_link: String::from("todo"),
+                    duration,
+                    enqueued_at: failed.from.from.enqueued_at,
+                    processed_at: failed.failed_at,
+                };
+                UpdateStatusResponse::Failed { content }
+            }
+        }
+    }
+}
 
 #[derive(Deserialize)]
 pub struct IndexParam {

--- a/meilisearch-http/tests/documents/add_documents.rs
+++ b/meilisearch-http/tests/documents/add_documents.rs
@@ -33,16 +33,14 @@ async fn add_documents_no_index_creation() {
     assert_eq!(code, 200);
     assert_eq!(response["status"], "processed");
     assert_eq!(response["updateId"], 0);
-    assert_eq!(response["success"]["DocumentsAddition"]["nb_documents"], 1);
+    assert_eq!(response["type"]["name"], "DocumentsAddition");
+    assert_eq!(response["type"]["number"], 1);
 
     let processed_at =
         DateTime::parse_from_rfc3339(response["processedAt"].as_str().unwrap()).unwrap();
     let enqueued_at =
         DateTime::parse_from_rfc3339(response["enqueuedAt"].as_str().unwrap()).unwrap();
-    let started_processing_at =
-        DateTime::parse_from_rfc3339(response["startedProcessingAt"].as_str().unwrap()).unwrap();
-    assert!(processed_at > started_processing_at);
-    assert!(started_processing_at > enqueued_at);
+    assert!(processed_at > enqueued_at);
 
     // index was created, and primary key was infered.
     let (response, code) = index.get().await;
@@ -86,7 +84,8 @@ async fn document_addition_with_primary_key() {
     assert_eq!(code, 200);
     assert_eq!(response["status"], "processed");
     assert_eq!(response["updateId"], 0);
-    assert_eq!(response["success"]["DocumentsAddition"]["nb_documents"], 1);
+    assert_eq!(response["type"]["name"], "DocumentsAddition");
+    assert_eq!(response["type"]["number"], 1);
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -113,7 +112,8 @@ async fn document_update_with_primary_key() {
     assert_eq!(code, 200);
     assert_eq!(response["status"], "processed");
     assert_eq!(response["updateId"], 0);
-    assert_eq!(response["success"]["DocumentsAddition"]["nb_documents"], 1);
+    assert_eq!(response["type"]["name"], "DocumentsPartial");
+    assert_eq!(response["type"]["number"], 1);
 
     let (response, code) = index.get().await;
     assert_eq!(code, 200);
@@ -282,7 +282,8 @@ async fn add_larger_dataset() {
     let (response, code) = index.get_update(update_id).await;
     assert_eq!(code, 200);
     assert_eq!(response["status"], "processed");
-    assert_eq!(response["success"]["DocumentsAddition"]["nb_documents"], 77);
+    assert_eq!(response["type"]["name"], "DocumentsAddition");
+    assert_eq!(response["type"]["number"], 77);
     let (response, code) = index
         .get_all_documents(GetAllDocumentsOptions {
             limit: Some(1000),
@@ -302,8 +303,8 @@ async fn update_larger_dataset() {
     index.wait_update_id(0).await;
     let (response, code) = index.get_update(0).await;
     assert_eq!(code, 200);
-    assert_eq!(response["status"], "processed");
-    assert_eq!(response["success"]["DocumentsAddition"]["nb_documents"], 77);
+    assert_eq!(response["type"]["name"], "DocumentsPartial");
+    assert_eq!(response["type"]["number"], 77);
     let (response, code) = index
         .get_all_documents(GetAllDocumentsOptions {
             limit: Some(1000),


### PR DESCRIPTION
Returns the update statuses with the same format as legacy meilisearch.

The number of documents in a document addition/deletion is not known before processing, so it is only returned when the update is `processed`.

close #78 

associated milli PR: https://github.com/meilisearch/milli/pull/178
