### PR TITLE
Enable filter paramater during search

### DIFF
--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -33,9 +33,8 @@ pub struct SearchQuery {
     pub attributes_to_crop: Option<HashSet<String>>,
     pub crop_length: Option<usize>,
     pub attributes_to_highlight: Option<HashSet<String>>,
-    pub filters: Option<String>,
     pub matches: Option<bool>,
-    pub facet_filters: Option<Value>,
+    pub filter: Option<Value>,
     pub facet_distributions: Option<Vec<String>>,
 }
 
@@ -75,8 +74,8 @@ impl Index {
         search.limit(query.limit);
         search.offset(query.offset.unwrap_or_default());
 
-        if let Some(ref facets) = query.facet_filters {
-            if let Some(facets) = parse_facets(facets, self, &rtxn)? {
+        if let Some(ref filter) = query.filter {
+            if let Some(facets) = parse_facets(filter, self, &rtxn)? {
                 search.facet_condition(facets);
             }
         }

--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -277,35 +277,6 @@ impl Matcher for MatchingWords {
     }
 }
 
-fn parse_facets_array(
-    txn: &RoTxn,
-    index: &Index,
-    arr: &[Value],
-) -> anyhow::Result<Option<FacetCondition>> {
-    let mut ands = Vec::new();
-    for value in arr {
-        match value {
-            Value::String(s) => ands.push(Either::Right(s.clone())),
-            Value::Array(arr) => {
-                let mut ors = Vec::new();
-                for value in arr {
-                    match value {
-                        Value::String(s) => ors.push(s.clone()),
-                        v => bail!("Invalid facet expression, expected String, found: {:?}", v),
-                    }
-                }
-                ands.push(Either::Left(ors));
-            }
-            v => bail!(
-                "Invalid facet expression, expected String or [String], found: {:?}",
-                v
-            ),
-        }
-    }
-
-    FacetCondition::from_array(txn, &index.0, ands)
-}
-
 struct Highlighter<'a, A> {
     analyzer: Analyzer<'a, A>,
     marks: (String, String),
@@ -367,11 +338,39 @@ fn parse_facets(
     txn: &RoTxn,
 ) -> anyhow::Result<Option<FacetCondition>> {
     match facets {
-        // Disabled for now
-        //Value::String(expr) => Ok(Some(FacetCondition::from_str(txn, index, expr)?)),
+        Value::String(expr) => Ok(Some(FacetCondition::from_str(txn, index, expr)?)),
         Value::Array(arr) => parse_facets_array(txn, index, arr),
         v => bail!("Invalid facet expression, expected Array, found: {:?}", v),
     }
+}
+
+fn parse_facets_array(
+    txn: &RoTxn,
+    index: &Index,
+    arr: &[Value],
+) -> anyhow::Result<Option<FacetCondition>> {
+    let mut ands = Vec::new();
+    for value in arr {
+        match value {
+            Value::String(s) => ands.push(Either::Right(s.clone())),
+            Value::Array(arr) => {
+                let mut ors = Vec::new();
+                for value in arr {
+                    match value {
+                        Value::String(s) => ors.push(s.clone()),
+                        v => bail!("Invalid facet expression, expected String, found: {:?}", v),
+                    }
+                }
+                ands.push(Either::Left(ors));
+            }
+            v => bail!(
+                "Invalid facet expression, expected String or [String], found: {:?}",
+                v
+            ),
+        }
+    }
+
+    FacetCondition::from_array(txn, &index.0, ands)
 }
 
 #[cfg(test)]

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -24,9 +24,8 @@ pub struct SearchQueryGet {
     attributes_to_crop: Option<String>,
     crop_length: Option<usize>,
     attributes_to_highlight: Option<String>,
-    filters: Option<String>,
+    filter: Option<String>,
     matches: Option<bool>,
-    facet_filters: Option<String>,
     facet_distributions: Option<String>,
 }
 
@@ -50,7 +49,7 @@ impl TryFrom<SearchQueryGet> for SearchQuery {
             .facet_distributions
             .map(|attrs| attrs.split(',').map(String::from).collect::<Vec<_>>());
 
-        let facet_filters = match other.facet_filters {
+        let filter = match other.filter {
             Some(ref f) => Some(serde_json::from_str(f)?),
             None => None,
         };
@@ -63,9 +62,8 @@ impl TryFrom<SearchQueryGet> for SearchQuery {
             attributes_to_crop,
             crop_length: other.crop_length,
             attributes_to_highlight,
-            filters: other.filters,
+            filter,
             matches: other.matches,
-            facet_filters,
             facet_distributions,
         })
     }

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::convert::{TryFrom, TryInto};
 
 use actix_web::{get, post, web, HttpResponse};
+use serde_json::Value;
 use serde::Deserialize;
 
 use crate::error::ResponseError;
@@ -50,7 +51,12 @@ impl TryFrom<SearchQueryGet> for SearchQuery {
             .map(|attrs| attrs.split(',').map(String::from).collect::<Vec<_>>());
 
         let filter = match other.filter {
-            Some(ref f) => Some(serde_json::from_str(f)?),
+            Some(f) => {
+                match serde_json::from_str(&f) {
+                    Ok(v) => Some(v),
+                    _ => Some(Value::String(f)),
+                }
+            },
             None => None,
         };
 


### PR DESCRIPTION
This pr makes the necessary changes to transplant in accordance with the specification on filters.

More precisely, it:
- Removes the `filters` parameter
- Renames `facetFilters` to `filter`
- Allows either a string or an array to be passed to the filter param.

It doesn't allow the mixed syntax, that needs to be handled by milli.

close #81
close #140
