### PR TITLE
Run cargo flaky only 100 times

### DIFF
--- a/.github/workflows/flaky.yml
+++ b/.github/workflows/flaky.yml
@@ -11,5 +11,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install cargo-flaky
       run: cargo install cargo-flaky
-    - name: Run cargo flaky 1000 times
-      run: cargo flaky -i 1000 --release
+    - name: Run cargo flaky 100 times
+      run: cargo flaky -i 100 --release


### PR DESCRIPTION
Look like the CI was not able to run cargo flaky 1000 times in 6 hours, so I guess, for now, we can come back to 100 times.

https://github.com/meilisearch/transplant/runs/2858159390
