### PR TITLE
Implement `matches`

### DIFF
--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -163,7 +163,11 @@ impl Index {
         );
 
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut documents = Vec::new();
 
@@ -174,7 +178,7 @@ impl Index {
 
             let matches_info = query
                 .matches
-                .then(|| compute_matches(&matching_words, &document));
+                .then(|| compute_matches(&matching_words, &document, &analyzer));
 
             let formatted = format_fields(
                 &fields_ids_map,
@@ -221,12 +225,12 @@ impl Index {
     }
 }
 
-fn compute_matches(matcher: &impl Matcher, document: &Document) -> MatchesInfo {
+fn compute_matches<A: AsRef<[u8]>>(
+    matcher: &impl Matcher,
+    document: &Document,
+    analyzer: &Analyzer<A>
+    ) -> MatchesInfo {
     let mut matches = BTreeMap::new();
-    let stop_words = fst::Set::default();
-    let mut config = AnalyzerConfig::default();
-    config.stop_words(&stop_words);
-    let analyzer = Analyzer::new(config);
 
     for (key, value) in document {
         let mut infos = Vec::new();
@@ -455,17 +459,12 @@ impl Matcher for MatchingWords {
 }
 
 struct Formatter<'a, A> {
-    analyzer: Analyzer<'a, A>,
+    analyzer: &'a Analyzer<'a, A>,
     marks: (String, String),
 }
 
 impl<'a, A: AsRef<[u8]>> Formatter<'a, A> {
-    pub fn new(stop_words: &'a fst::Set<A>, marks: (String, String)) -> Self {
-        let mut config = AnalyzerConfig::default();
-        config.stop_words(stop_words);
-
-        let analyzer = Analyzer::new(config);
-
+    pub fn new(analyzer: &'a Analyzer<'a, A>, marks: (String, String)) -> Self {
         Self { analyzer, marks }
     }
 
@@ -641,7 +640,10 @@ mod test {
     #[test]
     fn no_ids_no_formatted() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let id = fields.insert("test").unwrap();
@@ -673,7 +675,10 @@ mod test {
     #[test]
     fn formatted_with_highlight_in_word() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -734,7 +739,10 @@ mod test {
     #[test]
     fn formatted_with_crop_2() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -795,7 +803,10 @@ mod test {
     #[test]
     fn formatted_with_crop_10() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -856,7 +867,10 @@ mod test {
     #[test]
     fn formatted_with_crop_0() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -917,7 +931,10 @@ mod test {
     #[test]
     fn formatted_with_crop_and_no_match() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -978,7 +995,10 @@ mod test {
     #[test]
     fn formatted_with_crop_and_highlight() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -1039,7 +1059,10 @@ mod test {
     #[test]
     fn formatted_with_crop_and_highlight_in_word() {
         let stop_words = fst::Set::default();
-        let formatter = Formatter::new(&stop_words, (String::from("<em>"), String::from("</em>")));
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+        let formatter = Formatter::new(&analyzer, (String::from("<em>"), String::from("</em>")));
 
         let mut fields = FieldsIdsMap::new();
         let title = fields.insert("title").unwrap();
@@ -1140,7 +1163,12 @@ mod test {
         matcher.insert("mollit", Some(6));
         matcher.insert("laboris", Some(7));
 
-        let matches = compute_matches(&matcher, &value);
+        let stop_words = fst::Set::default();
+        let mut config = AnalyzerConfig::default();
+        config.stop_words(&stop_words);
+        let analyzer = Analyzer::new(config);
+
+        let matches = compute_matches(&matcher, &value, &analyzer);
         assert_eq!(format!("{:?}", matches), r##"{"about": [MatchInfo { start: 0, length: 6 }, MatchInfo { start: 31, length: 7 }, MatchInfo { start: 191, length: 7 }, MatchInfo { start: 225, length: 7 }, MatchInfo { start: 233, length: 6 }], "color": [MatchInfo { start: 0, length: 3 }]}"##);
     }
 }

--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -572,26 +572,23 @@ impl<'a, A: AsRef<[u8]>> Formatter<'a, A> {
             None => Box::new(analyzed.reconstruct()),
         };
 
-        tokens
-            .map(|(word, token)| {
-                // Check if we need to do highlighting or computed matches before calling
-                // Matcher::match since the call is expensive.
-                if format_options.highlight && token.is_word() {
-                    if let Some(length) = matcher.matches(token.text()) {
-                        if format_options.highlight {
-                            let mut new_word = String::new();
-                            new_word.push_str(&self.marks.0);
-                            new_word.push_str(&word[..length]);
-                            new_word.push_str(&self.marks.1);
-                            new_word.push_str(&word[length..]);
-
-                            return Cow::Owned(new_word);
-                        }
+        tokens.fold(String::new(), |mut out, (word, token)| {
+            // Check if we need to do highlighting or computed matches before calling
+            // Matcher::match since the call is expensive.
+            if format_options.highlight && token.is_word() {
+                if let Some(length) = matcher.matches(token.text()) {
+                    if format_options.highlight {
+                        out.push_str(&self.marks.0);
+                        out.push_str(&word[..length]);
+                        out.push_str(&self.marks.1);
+                        out.push_str(&word[length..]);
+                        return out;
                     }
                 }
-                Cow::Borrowed(word)
-            })
-            .collect::<String>()
+            }
+            out.push_str(word);
+            out
+        })
     }
 }
 

--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -173,7 +173,9 @@ impl Index {
         for (_id, obkv) in documents_iter {
             let document = make_document(&to_retrieve_ids, &fields_ids_map, obkv)?;
 
-            let matches_info = query.matches.then(|| compute_matches(&matching_words, &document));
+            let matches_info = query
+                .matches
+                .then(|| compute_matches(&matching_words, &document));
 
             let formatted = format_fields(
                 &fields_ids_map,

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -66,7 +66,7 @@ impl From<SearchQueryGet> for SearchQuery {
             crop_length: other.crop_length,
             attributes_to_highlight,
             filter,
-            matches: Some(other.matches),
+            matches: other.matches.unwrap_or_default(),
             facet_distributions,
         }
     }

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -66,7 +66,7 @@ impl From<SearchQueryGet> for SearchQuery {
             crop_length: other.crop_length,
             attributes_to_highlight,
             filter,
-            matches: other.matches.unwrap_or_default(),
+            matches: other.matches,
             facet_distributions,
         }
     }


### PR DESCRIPTION
implement `_matchesInfo`. I initially thought we could factor it inside the highlighting, but they are unrelated features after all, and needed a dedicated pass too handle.