### PR TITLE
fix get search crop len

### DIFF
--- a/meilisearch-http/src/index/mod.rs
+++ b/meilisearch-http/src/index/mod.rs
@@ -13,7 +13,7 @@ use serde_json::{Map, Value};
 use crate::helpers::EnvSizer;
 use error::Result;
 
-pub use search::{SearchQuery, SearchResult, DEFAULT_SEARCH_LIMIT};
+pub use search::{SearchQuery, SearchResult, DEFAULT_SEARCH_LIMIT, default_crop_length};
 pub use updates::{Checked, Facets, Settings, Unchecked};
 
 use self::error::IndexError;

--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -23,7 +23,7 @@ const fn default_search_limit() -> usize {
 }
 
 pub const DEFAULT_CROP_LENGTH: usize = 200;
-const fn default_crop_length() -> usize {
+pub const fn default_crop_length() -> usize {
     DEFAULT_CROP_LENGTH
 }
 

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::error::ResponseError;
 use crate::helpers::Authentication;
-use crate::index::{SearchQuery, DEFAULT_SEARCH_LIMIT};
+use crate::index::{SearchQuery, default_crop_length, DEFAULT_SEARCH_LIMIT};
 use crate::routes::IndexParam;
 use crate::Data;
 
@@ -22,10 +22,12 @@ pub struct SearchQueryGet {
     limit: Option<usize>,
     attributes_to_retrieve: Option<String>,
     attributes_to_crop: Option<String>,
+    #[serde(default = "default_crop_length")]
     crop_length: usize,
     attributes_to_highlight: Option<String>,
     filter: Option<String>,
-    matches: Option<bool>,
+    #[serde(default = "Default::default")]
+    matches: bool,
     facet_distributions: Option<String>,
 }
 
@@ -64,7 +66,7 @@ impl From<SearchQueryGet> for SearchQuery {
             crop_length: other.crop_length,
             attributes_to_highlight,
             filter,
-            matches: other.matches,
+            matches: Some(other.matches),
             facet_distributions,
         }
     }


### PR DESCRIPTION
Fix bug where crop length was mandatory when performing a GET search.
