### PR TITLE
Make facetsDistribution name iso

### DIFF
--- a/meilisearch-http/src/index/search.rs
+++ b/meilisearch-http/src/index/search.rs
@@ -49,7 +49,7 @@ pub struct SearchQuery {
     #[serde(default = "Default::default")]
     pub matches: bool,
     pub filter: Option<Value>,
-    pub facet_distributions: Option<Vec<String>>,
+    pub facets_distribution: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -73,7 +73,7 @@ pub struct SearchResult {
     pub offset: usize,
     pub processing_time_ms: u128,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub facet_distributions: Option<BTreeMap<String, BTreeMap<String, u64>>>,
+    pub facets_distribution: Option<BTreeMap<String, BTreeMap<String, u64>>>,
 }
 
 #[derive(Copy, Clone)]
@@ -198,13 +198,13 @@ impl Index {
 
         let nb_hits = candidates.len();
 
-        let facet_distributions = match query.facet_distributions {
+        let facets_distribution = match query.facets_distribution {
             Some(ref fields) => {
-                let mut facet_distribution = self.facets_distribution(&rtxn);
+                let mut facets_distribution = self.facets_distribution(&rtxn);
                 if fields.iter().all(|f| f != "*") {
-                    facet_distribution.facets(fields);
+                    facets_distribution.facets(fields);
                 }
-                let distribution = facet_distribution.candidates(candidates).execute()?;
+                let distribution = facets_distribution.candidates(candidates).execute()?;
 
                 Some(distribution)
             }
@@ -219,7 +219,7 @@ impl Index {
             limit: query.limit,
             offset: query.offset.unwrap_or_default(),
             processing_time_ms: before_search.elapsed().as_millis(),
-            facet_distributions,
+            facets_distribution,
         };
         Ok(result)
     }

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -28,7 +28,7 @@ pub struct SearchQueryGet {
     filter: Option<String>,
     #[serde(default = "Default::default")]
     matches: bool,
-    facet_distributions: Option<String>,
+    facets_distribution: Option<String>,
 }
 
 impl From<SearchQueryGet> for SearchQuery {
@@ -45,8 +45,8 @@ impl From<SearchQueryGet> for SearchQuery {
             .attributes_to_highlight
             .map(|attrs| attrs.split(',').map(String::from).collect::<HashSet<_>>());
 
-        let facet_distributions = other
-            .facet_distributions
+        let facets_distribution = other
+            .facets_distribution
             .map(|attrs| attrs.split(',').map(String::from).collect::<Vec<_>>());
 
         let filter = match other.filter {
@@ -67,7 +67,7 @@ impl From<SearchQueryGet> for SearchQuery {
             attributes_to_highlight,
             filter,
             matches: other.matches,
-            facet_distributions,
+            facets_distribution,
         }
     }
 }


### PR DESCRIPTION
Even if there is an English mistake in `facets_distribution` (because of the `s`) @gmourier asked me to keep the typo: the name of `facetsDistribution` might change completely in the future, he wants to avoid two breakings.

@gmourier can you confirm before we merge this PR?

Sorry I left this update in the code (I'm confused because no issues was open to update `facetsDistribution`), there might have been a confusion with `fieldsDistribution` that has been renamed into `fieldDistribution`. Sorry!