### PR TITLE
Rework error messages

### DIFF
--- a/meilisearch-http/src/error.rs
+++ b/meilisearch-http/src/error.rs
@@ -12,9 +12,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AuthenticationError {
-    #[error("you must have an authorization token")]
+    #[error("You must have an authorization token")]
     MissingAuthorizationHeader,
-    #[error("invalid API key")]
+    #[error("Invalid API key")]
     InvalidToken(String),
 }
 

--- a/meilisearch-http/src/index/error.rs
+++ b/meilisearch-http/src/index/error.rs
@@ -9,11 +9,11 @@ pub type Result<T> = std::result::Result<T, IndexError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IndexError {
-    #[error("internal error: {0}")]
+    #[error("Internal error: {0}")]
     Internal(Box<dyn Error + Send + Sync + 'static>),
-    #[error("document with id {0} not found.")]
+    #[error("Document with id {0} not found.")]
     DocumentNotFound(String),
-    #[error("error with facet: {0}")]
+    #[error("{0}")]
     Facet(#[from] FacetError),
     #[error("{0}")]
     Milli(#[from] milli::Error),
@@ -39,7 +39,7 @@ impl ErrorCode for IndexError {
 
 #[derive(Debug, thiserror::Error)]
 pub enum FacetError {
-    #[error("invalid facet expression, expected {}, found: {1}", .0.join(", "))]
+    #[error("Invalid facet expression, expected {}, found: {1}", .0.join(", "))]
     InvalidExpression(&'static [&'static str], Value),
 }
 

--- a/meilisearch-http/src/index_controller/dump_actor/error.rs
+++ b/meilisearch-http/src/index_controller/dump_actor/error.rs
@@ -7,15 +7,15 @@ pub type Result<T> = std::result::Result<T, DumpActorError>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum DumpActorError {
-    #[error("dump already running")]
+    #[error("Another dump is already in progress")]
     DumpAlreadyRunning,
-    #[error("dump `{0}` does not exist")]
+    #[error("Dump `{0}` not found")]
     DumpDoesNotExist(String),
-    #[error("internal error: {0}")]
+    #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
-    #[error("error while dumping uuids: {0}")]
+    #[error("{0}")]
     UuidResolver(#[from] UuidResolverError),
-    #[error("error while dumping updates: {0}")]
+    #[error("{0}")]
     UpdateActor(#[from] UpdateActorError),
 }
 

--- a/meilisearch-http/src/index_controller/error.rs
+++ b/meilisearch-http/src/index_controller/error.rs
@@ -12,24 +12,24 @@ pub type Result<T> = std::result::Result<T, IndexControllerError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum IndexControllerError {
-    #[error("missing index uid")]
+    #[error("Index creation must have an uid")]
     MissingUid,
-    #[error("index resolution error: {0}")]
+    #[error("{0}")]
     Uuid(#[from] UuidResolverError),
-    #[error("error with index: {0}")]
+    #[error("{0}")]
     IndexActor(#[from] IndexActorError),
-    #[error("error with update: {0}")]
+    #[error("{0}")]
     UpdateActor(#[from] UpdateActorError),
-    #[error("error with dump: {0}")]
+    #[error("{0}")]
     DumpActor(#[from] DumpActorError),
-    #[error("error with index: {0}")]
+    #[error("{0}")]
     IndexError(#[from] IndexError),
 }
 
 impl ErrorCode for IndexControllerError {
     fn error_code(&self) -> Code {
         match self {
-            IndexControllerError::MissingUid => Code::InvalidIndexUid,
+            IndexControllerError::MissingUid => Code::BadRequest,
             IndexControllerError::Uuid(e) => e.error_code(),
             IndexControllerError::IndexActor(e) => e.error_code(),
             IndexControllerError::UpdateActor(e) => e.error_code(),

--- a/meilisearch-http/src/index_controller/index_actor/error.rs
+++ b/meilisearch-http/src/index_controller/index_actor/error.rs
@@ -6,15 +6,15 @@ pub type Result<T> = std::result::Result<T, IndexActorError>;
 
 #[derive(thiserror::Error, Debug)]
 pub enum IndexActorError {
-    #[error("index error: {0}")]
+    #[error("{0}")]
     IndexError(#[from] IndexError),
-    #[error("index already exists")]
+    #[error("Index already exists")]
     IndexAlreadyExists,
-    #[error("index doesn't exists")]
+    #[error("Index not found")]
     UnexistingIndex,
-    #[error("existing primary key")]
+    #[error("A primary key is already present. It's impossible to update it")]
     ExistingPrimaryKey,
-    #[error("internal Index Error: {0}")]
+    #[error("Internal Error: {0}")]
     Internal(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("{0}")]
     Milli(#[from] milli::Error),

--- a/meilisearch-http/src/index_controller/update_actor/error.rs
+++ b/meilisearch-http/src/index_controller/update_actor/error.rs
@@ -9,19 +9,19 @@ pub type Result<T> = std::result::Result<T, UpdateActorError>;
 #[derive(Debug, thiserror::Error)]
 #[allow(clippy::large_enum_variant)]
 pub enum UpdateActorError {
-    #[error("update {0} doesn't exist.")]
+    #[error("Update {0} not found.")]
     UnexistingUpdate(u64),
-    #[error("internal error processing update: {0}")]
+    #[error("Internal error: {0}")]
     Internal(Box<dyn Error + Send + Sync + 'static>),
-    #[error("error with index: {0}")]
+    #[error("{0}")]
     IndexActor(#[from] IndexActorError),
     #[error(
         "update store was shut down due to a fatal error, please check your logs for more info."
     )]
     FatalUpdateStoreError,
-    #[error("invalid payload: {0}")]
+    #[error("{0}")]
     InvalidPayload(Box<dyn Error + Send + Sync + 'static>),
-    #[error("payload error: {0}")]
+    #[error("{0}")]
     PayloadError(#[from] actix_web::error::PayloadError),
 }
 

--- a/meilisearch-http/src/index_controller/uuid_resolver/error.rs
+++ b/meilisearch-http/src/index_controller/uuid_resolver/error.rs
@@ -4,13 +4,13 @@ pub type Result<T> = std::result::Result<T, UuidResolverError>;
 
 #[derive(Debug, thiserror::Error)]
 pub enum UuidResolverError {
-    #[error("name already exist.")]
+    #[error("Index already exists.")]
     NameAlreadyExist,
-    #[error("index \"{0}\" doesn't exist.")]
+    #[error("Index \"{0}\" not found.")]
     UnexistingIndex(String),
-    #[error("badly formatted index uid: {0}")]
+    #[error("Index must have a valid uid; Index uid can be of type integer or string only composed of alphanumeric characters, hyphens (-) and underscores (_).")]
     BadlyFormatted(String),
-    #[error("internal error resolving index uid: {0}")]
+    #[error("Internal error: {0}")]
     Internal(Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 


### PR DESCRIPTION
Simplify the error messages, and make them more compliant with legacy Meilisearch.

Basically, stop composing the messages, and simply forward the message of inner errors.
