### PR TITLE
Use half of the computer threads for the indexing process by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,7 @@ dependencies = [
  "milli",
  "mime",
  "mockall",
+ "num_cpus",
  "obkv",
  "once_cell",
  "oxidized-json-checker",

--- a/meilisearch-http/Cargo.toml
+++ b/meilisearch-http/Cargo.toml
@@ -53,6 +53,7 @@ meilisearch-tokenizer = { git = "https://github.com/meilisearch/tokenizer.git", 
 memmap = "0.7.0"
 milli = { git = "https://github.com/meilisearch/milli.git", tag = "v0.6.0" }
 mime = "0.3.16"
+num_cpus = "1.13.0"
 once_cell = "1.5.2"
 oxidized-json-checker = "0.3.2"
 parking_lot = "0.11.1"

--- a/meilisearch-http/src/index/update_handler.rs
+++ b/meilisearch-http/src/index/update_handler.rs
@@ -23,7 +23,7 @@ pub struct UpdateHandler {
 impl UpdateHandler {
     pub fn new(opt: &IndexerOpts) -> anyhow::Result<Self> {
         let thread_pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(opt.indexing_jobs.unwrap_or(0))
+            .num_threads(opt.indexing_jobs.unwrap_or(num_cpus::get() / 2))
             .build()?;
         Ok(Self {
             max_nb_chunks: opt.max_nb_chunks,


### PR DESCRIPTION
closes #241 
By default, we use only half of the CPU threads when indexing documents; this allows the user to use the search while indexing. Also, the machine will not appear unresponsive when indexing a large batch of documents.

On the special case where a user only has one core, we use it entirely :smile: 