### PR TITLE
Do not block when sending update notifications

### DIFF
--- a/meilisearch-http/src/extractors/authentication/error.rs
+++ b/meilisearch-http/src/extractors/authentication/error.rs
@@ -23,4 +23,3 @@ impl ErrorCode for AuthenticationError {
         }
     }
 }
-

--- a/meilisearch-http/src/index_controller/update_actor/actor.rs
+++ b/meilisearch-http/src/index_controller/update_actor/actor.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use async_stream::stream;
 use futures::StreamExt;
-use log::{trace};
+use log::trace;
 use oxidized_json_checker::JsonChecker;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;

--- a/meilisearch-http/src/index_controller/update_actor/store/mod.rs
+++ b/meilisearch-http/src/index_controller/update_actor/store/mod.rs
@@ -120,7 +120,7 @@ impl UpdateStore {
 
         let state = Arc::new(StateLock::from_state(State::Idle));
 
-        let (notification_sender, notification_receiver) = mpsc::channel(10);
+        let (notification_sender, notification_receiver) = mpsc::channel(1);
 
         Ok((
             Self {
@@ -151,10 +151,7 @@ impl UpdateStore {
         // Init update loop to perform any pending updates at launch.
         // Since we just launched the update store, and we still own the receiving end of the
         // channel, this call is guaranteed to succeed.
-        update_store
-            .notification_sender
-            .try_send(())
-            .expect("Failed to init update store");
+        let _ = update_store.notification_sender.try_send(());
 
         // We need a weak reference so we can take ownership on the arc later when we
         // want to close the index.
@@ -245,9 +242,8 @@ impl UpdateStore {
 
         txn.commit()?;
 
-        self.notification_sender
-            .blocking_send(())
-            .expect("Update store loop exited.");
+        let _ = self.notification_sender.try_send(());
+
         Ok(meta)
     }
 

--- a/meilisearch-http/src/routes/document.rs
+++ b/meilisearch-http/src/routes/document.rs
@@ -33,16 +33,16 @@ guard_content_type!(guard_json, "application/json");
 */
 
 fn guard_json(head: &actix_web::dev::RequestHead) -> bool {
-            if let Some(content_type) = head.headers.get("Content-Type") {
-                content_type
-                    .to_str()
-                    .map(|v| v.contains("application/json"))
-                    .unwrap_or(false)
-            } else {
-                // if no content-type is specified we still accept the data as json!
-                true
-            }
-        }
+    if let Some(content_type) = head.headers.get("Content-Type") {
+        content_type
+            .to_str()
+            .map(|v| v.contains("application/json"))
+            .unwrap_or(false)
+    } else {
+        // if no content-type is specified we still accept the data as json!
+        true
+    }
+}
 
 #[derive(Deserialize)]
 struct DocumentParam {

--- a/meilisearch-http/src/routes/dump.rs
+++ b/meilisearch-http/src/routes/dump.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use actix_web::{web, HttpResponse};
+use log::debug;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ResponseError;

--- a/meilisearch-http/src/routes/index.rs
+++ b/meilisearch-http/src/routes/index.rs
@@ -21,12 +21,11 @@ pub fn services(cfg: &mut web::ServiceConfig) {
             .route(web::delete().to(delete_index)),
     )
     .service(
-        web::resource("/indexes/{index_uid}/updates")
-        .route(web::get().to(get_all_updates_status))
+        web::resource("/indexes/{index_uid}/updates").route(web::get().to(get_all_updates_status)),
     )
     .service(
         web::resource("/indexes/{index_uid}/updates/{update_id}")
-        .route(web::get().to(get_update_status))
+            .route(web::get().to(get_update_status)),
     );
 }
 

--- a/meilisearch-http/src/routes/search.rs
+++ b/meilisearch-http/src/routes/search.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeSet, HashSet};
 
-use log::debug;
 use actix_web::{web, HttpResponse};
+use log::debug;
 use serde::Deserialize;
 use serde_json::Value;
 

--- a/meilisearch-http/src/routes/settings.rs
+++ b/meilisearch-http/src/routes/settings.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use actix_web::{web, HttpResponse};
+use log::debug;
 
 use crate::extractors::authentication::{policies::*, GuardedData};
 use crate::index::Settings;

--- a/meilisearch-http/src/routes/stats.rs
+++ b/meilisearch-http/src/routes/stats.rs
@@ -1,5 +1,5 @@
-use log::debug;
 use actix_web::{web, HttpResponse};
+use log::debug;
 use serde::Serialize;
 
 use crate::error::ResponseError;


### PR DESCRIPTION
We tried this on a custom build with @curquiza and it works, it fixes #251, let me know what do you think about this fix.
It seems to be due to Transplant `panic`king from an `expect` which was closing the TCP connection on the Ruby side.